### PR TITLE
Comparison Resolver 

### DIFF
--- a/core/enums.py
+++ b/core/enums.py
@@ -17,3 +17,7 @@ class EndpointName(Enum):
     COMPONENTS = "components"
     FLAGS = "flags"
     COVERAGE_TRENDS = "coverage-trends"
+    COMPARISON = "compare"
+    COMPONENT_COMPARISON = "compare-component"
+    FILE_COMPARISON = "compare-file"
+    FLAG_COMPARISON = "compare-flag"

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -98,6 +98,26 @@ endpoint_mapping: Dict[EndpointName, Command] = {
         ],
         is_private=True,
     ),
+    EndpointName.COMPARISON: Command(
+        required_params=["username", "service", "repository"],
+        optional_params=["pullid", "base", "head"],
+        is_private=True,
+    ),
+    EndpointName.COMPONENT_COMPARISON: Command(
+        required_params=["username", "service", "repository"],
+        optional_params=["pullid", "base", "head"],
+        is_private=True,
+    ),
+    EndpointName.FILE_COMPARISON: Command(
+        required_params=["username", "service", "repository", "path"],
+        optional_params=["pullid", "base", "head"],
+        is_private=True,
+    ),
+    EndpointName.FLAG_COMPARISON: Command(
+        required_params=["username", "service", "repository"],
+        optional_params=["pullid", "base", "head"],
+        is_private=True,
+    ),
 }
 
 service_mapping = {
@@ -157,3 +177,13 @@ def format_nested_keys(data, formatted_data):
             formatted_data += f"*{key.capitalize()}*: {res[key]}\n"
         formatted_data += "------------------\n"
     return formatted_data
+
+
+def validate_comparison_params(params_dict):
+    base = params_dict.get("base")
+    head = params_dict.get("head")
+    pull_id = params_dict.get("pullid")
+    if (not base or not head) and (not pull_id):
+        raise Exception(
+            "Comparison requires both a base and head parameter or a pullid parameter"
+        )

--- a/core/slack_listeners.py
+++ b/core/slack_listeners.py
@@ -4,12 +4,15 @@ import os
 from slack_bolt import App
 from slack_bolt.oauth.oauth_settings import OAuthSettings
 
+from core.enums import EndpointName
+
 from .resolvers import (BranchesResolver, BranchResolver, CommitResolver,
-                        CommitsResolver, ComponentsResolver,
-                        CoverageTrendsResolver, FlagsResolver, OrgsResolver,
-                        OwnerResolver, PullResolver, PullsResolver,
-                        RepoConfigResolver, RepoResolver, ReposResolver,
-                        UsersResolver, resolve_help, resolve_service_login,
+                        CommitsResolver, ComparisonResolver,
+                        ComponentsResolver, CoverageTrendsResolver,
+                        FlagsResolver, OrgsResolver, OwnerResolver,
+                        PullResolver, PullsResolver, RepoConfigResolver,
+                        RepoResolver, ReposResolver, UsersResolver,
+                        resolve_help, resolve_service_login,
                         resolve_service_logout)
 from .slack_datastores import DjangoInstallationStore, DjangoOAuthStateStore
 
@@ -107,8 +110,33 @@ def handle_codecov_commands(ack, command, say, client):
                 ComponentsResolver(client, command, say)()
             case "flags":
                 FlagsResolver(client, command, say)()
-            case "coverage-trends": # use endpoint enum for cases
+            case "coverage-trends":  # use endpoint enum for cases
                 CoverageTrendsResolver(client, command, say)()
+            case "compare":
+                ComparisonResolver(
+                    client, command, say, command_name=EndpointName.COMPARISON
+                )()
+            case "compare-component":
+                ComparisonResolver(
+                    client,
+                    command,
+                    say,
+                    command_name=EndpointName.COMPONENT_COMPARISON,
+                )()
+            case "compare-file":
+                ComparisonResolver(
+                    client,
+                    command,
+                    say,
+                    command_name=EndpointName.FILE_COMPARISON,
+                )()
+            case "compare-flag":
+                ComparisonResolver(
+                    client,
+                    command,
+                    say,
+                    command_name=EndpointName.FLAG_COMPARISON,
+                )()
             case "help":
                 resolve_help(say)
             case _:

--- a/service_auth/helpers.py
+++ b/service_auth/helpers.py
@@ -66,6 +66,7 @@ def get_endpoint_details(
     commit_id = params_dict.get("commitid")
     pull_id = params_dict.get("pullid")
     flag = params_dict.get("flag")
+    file_path = params_dict.get("path")
 
     endpoints_map: Dict[EndpointName, Endpoint] = {
         EndpointName.SERVICE_OWNERS: Endpoint(
@@ -112,6 +113,18 @@ def get_endpoint_details(
         ),
         EndpointName.COVERAGE_TRENDS: Endpoint(
             url=f"{CODECOV_PUBLIC_API}/{service}/{owner_username}/repos/{repository}/flags/{flag}/coverage/",
+        ),
+        EndpointName.COMPARISON: Endpoint(
+            url=f"{CODECOV_PUBLIC_API}/{service}/{owner_username}/repos/{repository}/compare/",
+        ),
+        EndpointName.COMPONENT_COMPARISON: Endpoint(
+            url=f"{CODECOV_PUBLIC_API}/{service}/{owner_username}/repos/{repository}/compare/components/",
+        ),
+        EndpointName.FILE_COMPARISON: Endpoint(
+            url=f"{CODECOV_PUBLIC_API}/{service}/{owner_username}/repos/{repository}/compare/file/{file_path}/",
+        ),
+        EndpointName.FLAG_COMPARISON: Endpoint(
+            url=f"{CODECOV_PUBLIC_API}/{service}/{owner_username}/repos/{repository}/compare/flags/",
         ),
     }
 


### PR DESCRIPTION
# Summary 
It seems like the comparison stuff are returning the same responses, I added a single resolver that accepts an endpoint name, where the nested resolver takes care of the rest. There was also some huge responses that i handled by splitting up the response and attaching the rest of the response in threads if it's more than 4000 letters. 

# Changes 
- New `ComparisonResolver`
- New endpoints 
- New split, post message, and post in thread message functions in `BaseResolver`
- Updated slack listeners
- Updated help message :D 

# Additional Notes
<img width="788" alt="Screenshot 2023-05-04 at 4 54 50 PM" src="https://user-images.githubusercontent.com/91732700/236230944-3c530b94-d68a-49fe-ad4f-5d6848d02d4f.png">
