### PR TITLE
Notify users on failed/successful login attempts

### DIFF
--- a/service_auth/helpers.py
+++ b/service_auth/helpers.py
@@ -38,6 +38,8 @@ def validate_gh_call_params(code, state):
         raise ValidationError("Missing code parameter")
     if not state:
         raise ValidationError("Missing state parameter")
+    if "-" not in state or len(state.split("-")) != 2:
+        raise ValidationError("Invalid state parameter")
 
 
 def get_github_user(access_token):
@@ -151,7 +153,7 @@ def get_endpoint_details(
     return endpoint
 
 
-def notify_user_of_error(user, channel_id=None):
+def notify_user(user, channel_id=None, message=""):
     team_id = user.team_id
     installation = SlackInstallation.objects.filter(team_id=team_id).first()
     if not installation:
@@ -162,20 +164,5 @@ def notify_user_of_error(user, channel_id=None):
     client = WebClient(token=installation.bot_token)
     client.chat_postMessage(
         channel=channel_id or user.user_id,
-        text=f"Error creating Codecov access token for {user.username}, are you sure you have a Codecov account?",
-    )
-
-
-def notify_user_of_successful_auth(user, channel_id=None):
-    team_id = user.team_id
-    installation = SlackInstallation.objects.filter(team_id=team_id).first()
-    if not installation:
-        return Response(
-            {"detail": f"Slack installation not found {team_id}"}, status=404
-        )
-
-    client = WebClient(token=installation.bot_token)
-    client.chat_postMessage(
-        channel=channel_id or user.user_id,
-        text=f"Successfully authenticated with Codecov",
+        text=message,
     )

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -103,6 +103,6 @@ class GithubCallbackView(APIView):
         team_id = user.team_id
         slack_url = f"https://slack.com/app_redirect?app={SLACK_APP_ID}&channel={channel_id}&team={team_id}"
 
-        message = "Successfully connected your GitHub account to Codecov"
+        message = "Successfully connected your GitHub account to Codecov!"
         notify_user(user, channel_id, message=message)
         return redirect(slack_url)

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -103,6 +103,6 @@ class GithubCallbackView(APIView):
         team_id = user.team_id
         slack_url = f"https://slack.com/app_redirect?app={SLACK_APP_ID}&channel={channel_id}&team={team_id}"
 
-        message = "Successfully connected your GitHub account to Codecov! You can now use Codecov commands in this channel."
+        message = "Successfully connected your GitHub account to Codecov!"
         notify_user(user, channel_id, message=message)
         return redirect(slack_url)

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -103,6 +103,6 @@ class GithubCallbackView(APIView):
         team_id = user.team_id
         slack_url = f"https://slack.com/app_redirect?app={SLACK_APP_ID}&channel={channel_id}&team={team_id}"
 
-        message = "Successfully connected your GitHub account to Codecov!"
+        message = "Successfully connected your GitHub account to Codecov"
         notify_user(user, channel_id, message=message)
         return redirect(slack_url)

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -7,7 +7,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .actions import create_new_codecov_access_token
-from .helpers import get_github_user, validate_gh_call_params
+from .helpers import (get_github_user, notify_user_of_error,
+                      notify_user_of_successful_auth, validate_gh_call_params)
 from .models import Service, SlackUser
 
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID")
@@ -27,9 +28,11 @@ class GithubCallbackView(APIView):
         # Get the authorization code from the GitHub's callback request
         code = request.GET.get("code")
         state = request.GET.get("state")
-        user_id = jwt.decode(state, USER_ID_SECRET, algorithms=["HS256"])[
-            "user_id"
-        ]
+        user_id_state = state.split("-")[0]
+        user_id = jwt.decode(
+            user_id_state, USER_ID_SECRET, algorithms=["HS256"]
+        )["user_id"]
+        channel_id = state.split("-")[1]
 
         validate_gh_call_params(code, state)
 
@@ -67,7 +70,9 @@ class GithubCallbackView(APIView):
 
         user = SlackUser.objects.filter(user_id=user_id).first()
         if not user:
-            return Response({"detail": f"Slack user not found {user_id}"}, status=404)
+            return Response(
+                {"detail": f"Slack user not found {user_id}"}, status=404
+            )
 
         service = Service.objects.filter(user=user, name=provider).first()
         if not service:
@@ -83,12 +88,20 @@ class GithubCallbackView(APIView):
         service.save()
 
         # create new codecov access token
-        create_new_codecov_access_token(user)
+        try:
+            create_new_codecov_access_token(user)
+        except Exception as e:
+            notify_user_of_error(user, channel_id)
+            return Response(
+                {
+                    "detail": "Error creating Codecov access token, are you sure you have a Codecov account?"
+                },
+                status=400,
+            )
 
         # redirect to slack app
         team_id = user.team_id
-        slack_url = (
-            f"https://slack.com/app_redirect?app={SLACK_APP_ID}&team={team_id}"
-        )
+        slack_url = f"https://slack.com/app_redirect?app={SLACK_APP_ID}&channel={channel_id}&team={team_id}"
 
+        notify_user_of_successful_auth(user, channel_id)
         return redirect(slack_url)


### PR DESCRIPTION
# Summary 
This is an attempt to guide users into creating Codecov accounts before actually using the app, also notifying users upon successful authentication flow. 

# Changes 
- New helpers to better raise app logs post authentications 
- Audited github callback to send the channel id 


# Additional Notes
Just gotta test this on staging 
