### PR TITLE
Resolve feedback

### DIFF
--- a/core/resolvers.py
+++ b/core/resolvers.py
@@ -75,16 +75,18 @@ class BaseResolver:
 
     def post_snippet(self, message):
         try:
-            response = self.client.conversations_info(channel=self.command["channel_id"])
-            channel = response['channel']
+            response = self.client.conversations_info(
+                channel=self.command["channel_id"]
+            )
+            channel = response["channel"]
 
             # Check if it's not a DM with App
-            if not channel['is_im']:
+            if not channel["is_im"]:
                 self.client.chat_postEphemeral(
-                channel=self.command["channel_id"],
-                user=self.command["user_id"],
-                text=f"Response too large to display here. you can find it in the Codecov app's DMs",
-            )
+                    channel=self.command["channel_id"],
+                    user=self.command["user_id"],
+                    text=f"Response too large to display here. you can find it in the Codecov app's DMs",
+                )
 
             # Upload the file to bot's direct message
             response = self.client.files_upload(
@@ -218,6 +220,14 @@ def resolve_help(channel_id, user_id, client):
             "text": {
                 "type": "mrkdwn",
                 "text": "`/codecov help` - Get help\n*Note* that some of commands require you to login to a service first. \n\n",
+            },
+        },
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "✨ *Want to see more commands?* ✨\n\nClick on the bot's name and check out the *Home* tab for additional options and features!",
             },
         },
     ]
@@ -603,9 +613,7 @@ class FileCoverageReport(BaseResolver):
         if not data:
             return f"No coverage report found for {path} in {repo}"
 
-        formatted_data = (
-            f"*Coverage report for {path} in {repo}*:\n"
-        )
+        formatted_data = f"*Coverage report for {path} in {repo}*:\n"
         for key in data:
             formatted_data += f"{key.capitalize()}: {data[key]}\n"
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+from django.shortcuts import redirect
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 from slack_bolt.adapter.django import SlackRequestHandler
@@ -15,6 +16,9 @@ def slack_events_handler(request: HttpRequest):
 
 
 def slack_oauth_handler(request: HttpRequest):
+    if "error" in request.GET:
+        return redirect("/slack/install")
+
     return handler.handle(request)
 
 

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -2,6 +2,7 @@ import os
 
 import jwt
 import requests
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -95,9 +96,7 @@ class GithubCallbackView(APIView):
             if error:
                 return error
 
-            return Response(
-                {"detail": "Error creating Codecov access token"}, status=400
-            )
+            return HttpResponse(message, content_type="application/json")
 
         # redirect to slack app
         team_id = user.team_id

--- a/service_auth/views.py
+++ b/service_auth/views.py
@@ -2,7 +2,6 @@ import os
 
 import jwt
 import requests
-from django.http import HttpResponse
 from django.shortcuts import redirect
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -96,7 +95,9 @@ class GithubCallbackView(APIView):
             if error:
                 return error
 
-            return HttpResponse(message, content_type="application/json")
+            return Response(
+                {"detail": "Error creating Codecov access token"}, status=400
+            )
 
         # redirect to slack app
         team_id = user.team_id


### PR DESCRIPTION
# Summary 
Their feedback:

> a) When installing the app and selecting "Cancel" instead of accepting the permissions, a default error is returned. Could you please ensure the user is redirected to a page that is more useful in this instance (e.g. back to the app's landing page). b) Please ensure a proper slash command response is returned in each conversation type where the command is triggered. For instance, when using the `/codecov` command with no input/invalid input or the `/codecov help` command (in a conversation that the bot is not a member of), there is no response returned in Slack. This can be done by using the `response_URL` to return a response: https://api.slack.com/interactivity/handling#message_responses. c) Also, it looks like there are more slash commands included in the app's "Home" tab than in the app's slash command "help" response. Please ensure all supported commands are included in this response as well.


# Changes 
- Update to redirect to /install on cancelled permission access 
- Update to return errors on calling slack in a channel where the bot does not exist 
- Update to return some form of response in when calling `/codecov`
- Update help message to tell user to look at the home page 

<img width="982" alt="Screenshot 2024-08-13 at 2 07 45 PM" src="https://github.com/user-attachments/assets/0dd5b6f6-ead5-4470-ac11-54f186d4c7fd">
<img width="982" alt="Screenshot 2024-08-13 at 2 09 20 PM" src="https://github.com/user-attachments/assets/0eeb1fec-6454-484a-8e94-710af3d2be45">
<img width="982" alt="Screenshot 2024-08-13 at 2 10 16 PM" src="https://github.com/user-attachments/assets/1220112e-38dc-4d81-ae85-27b124588828">



https://github.com/user-attachments/assets/38de8757-3cd6-425e-86c6-ef60aab6f5f9

