### PR TITLE
fix(security): bump Django 5.0.14 -> 5.1.15, certifi, django-csp

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
-Django
+Django>=5.1,<5.2
 asgiref
-django-csp
+django-csp>=3.8
 djangorestframework
 gunicorn
 httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ asgiref==3.7.2
     # via
     #   -r requirements.in
     #   django
-certifi==2024.7.4
+certifi==2025.1.31
     # via
     #   httpcore
     #   httpx
@@ -18,12 +18,12 @@ certifi==2024.7.4
     #   sentry-sdk
 charset-normalizer==3.1.0
     # via requests
-django==5.0.14
+django==5.1.15
     # via
     #   -r requirements.in
     #   django-csp
     #   djangorestframework
-django-csp==3.7
+django-csp==3.8
     # via -r requirements.in
 djangorestframework==3.15.2
     # via -r requirements.in


### PR DESCRIPTION
## Summary

- **Django** 5.0.14 -> 5.1.15: Django 5.0 is EOL; 5.1.15 fixes CVE-2025-64459 and CVE-2026-1207
- **certifi** 2024.7.4 -> 2025.1.31: updated CA certificate bundle
- **django-csp** 3.7 -> 3.8: required for Django 5.1 compatibility

## Issues

## Test plan

- [ ] CI passes
- [ ] Verify Slack app boots correctly with Django 5.1
- [ ] Verify django-csp 3.8 is compatible with existing CSP config
- [ ] Smoke-test Slack bot interactions

Made with [Cursor](https://cursor.com)