### PR TITLE
chore(sentry): disable Django middleware span auto-instrumentation

### DIFF
--- a/codecov_slack_app/settings.py
+++ b/codecov_slack_app/settings.py
@@ -175,7 +175,10 @@ SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 0.1))
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
-    integrations=[DjangoIntegration(), HttpxIntegration()],
+    integrations=[
+        DjangoIntegration(middleware_spans=False),
+        HttpxIntegration(),
+    ],
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production,


### PR DESCRIPTION
## Summary

Adds `middleware_spans=False` to `DjangoIntegration` in `codecov_slack_app/settings.py` so per-middleware spans stop being auto-emitted.

## Why

Auto-instrumented `middleware.django` spans don't carry useful debugging information. A `middleware.django` span carries only `span.description` (the FQN of the middleware method) and `span.duration` — no middleware-specific attributes, no headers, no auth context. Because Django middleware wraps `get_response`, the `__call__` duration is bounded by the chain below it and clusters at the request-envelope value, so individual middleware spans rarely identify a real bottleneck.

Everything debuggable (the request envelope, ORM queries, outbound HTTP via HttpxIntegration, view rendering) is on its own span and is **not affected** by this change.

If a specific custom middleware ever needs targeted timing, we can manually wrap it with `sentry_sdk.start_span(op="middleware.codecov", description="…")`.

## Test plan

- [ ] CI green
- [ ] After deploy, confirm `span.op:middleware.django` count drops to ~0 for the slack-app project
- [ ] Confirm transaction throughput and p95 latency are unchanged on the parent (http.server) span

## Refs

- Sentry SDK docs: https://docs.sentry.io/platforms/python/integrations/django/#options